### PR TITLE
fix: align interface argument names with implementation

### DIFF
--- a/src/interfaces/IJBDirectory.sol
+++ b/src/interfaces/IJBDirectory.sol
@@ -18,13 +18,13 @@ interface IJBDirectory {
     function PROJECTS() external view returns (IJBProjects);
 
     function controllerOf(uint256 projectId) external view returns (IERC165);
-    function isAllowedToSetFirstController(address account) external view returns (bool);
+    function isAllowedToSetFirstController(address addr) external view returns (bool);
     function isTerminalOf(uint256 projectId, IJBTerminal terminal) external view returns (bool);
     function primaryTerminalOf(uint256 projectId, address token) external view returns (IJBTerminal);
     function terminalsOf(uint256 projectId) external view returns (IJBTerminal[] memory);
 
     function setControllerOf(uint256 projectId, IERC165 controller) external;
-    function setIsAllowedToSetFirstController(address account, bool flag) external;
+    function setIsAllowedToSetFirstController(address addr, bool flag) external;
     function setPrimaryTerminalOf(uint256 projectId, address token, IJBTerminal terminal) external;
     function setTerminalsOf(uint256 projectId, IJBTerminal[] calldata terminals) external;
 }

--- a/src/interfaces/IJBFeelessAddresses.sol
+++ b/src/interfaces/IJBFeelessAddresses.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 interface IJBFeelessAddresses {
     event SetFeelessAddress(address indexed addr, bool indexed isFeeless, address caller);
 
-    function isFeeless(address account) external view returns (bool);
+    function isFeeless(address addr) external view returns (bool);
 
-    function setFeelessAddress(address account, bool flag) external;
+    function setFeelessAddress(address addr, bool flag) external;
 }

--- a/src/interfaces/IJBPayoutTerminal.sol
+++ b/src/interfaces/IJBPayoutTerminal.sol
@@ -58,7 +58,7 @@ interface IJBPayoutTerminal is IJBTerminal {
         uint256 minTokensPaidOut
     )
         external
-        returns (uint256 netLeftoverPayoutAmount);
+        returns (uint256 amountPaidOut);
     function useAllowanceOf(
         uint256 projectId,
         address token,

--- a/src/interfaces/IJBTerminalStore.sol
+++ b/src/interfaces/IJBTerminalStore.sol
@@ -40,7 +40,7 @@ interface IJBTerminalStore {
 
     function currentReclaimableSurplusOf(
         uint256 projectId,
-        uint256 tokenCount,
+        uint256 cashOutCount,
         uint256 totalSupply,
         uint256 surplus
     )

--- a/src/interfaces/IJBTokens.sol
+++ b/src/interfaces/IJBTokens.sol
@@ -36,7 +36,7 @@ interface IJBTokens {
     function tokenOf(uint256 projectId) external view returns (IJBToken);
     function totalCreditSupplyOf(uint256 projectId) external view returns (uint256);
 
-    function totalBalanceOf(address holder, uint256 projectId) external view returns (uint256 result);
+    function totalBalanceOf(address holder, uint256 projectId) external view returns (uint256 balance);
     function totalSupplyOf(uint256 projectId) external view returns (uint256);
 
     function burnFrom(address holder, uint256 projectId, uint256 count) external;


### PR DESCRIPTION
Fixes argument name mismatches in IJBFeelessAddresses, IJBDirectory, IJBTerminalStore, IJBTokens, and IJBPayoutTerminal to match their implementations.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: