### PR TITLE
docs(NCI-1): document data hook trust boundary in recordCashOutFor

### DIFF
--- a/src/JBTerminalStore.sol
+++ b/src/JBTerminalStore.sol
@@ -644,6 +644,11 @@ contract JBTerminalStore is IJBTerminalStore {
         // The weight according to which new tokens are to be minted, as a fixed point number with 18 decimals.
         uint256 weight;
 
+        // SECURITY NOTE: The data hook has absolute control over payment token minting.
+        // It can return an arbitrary weight (overriding the ruleset's weight) and hook specifications
+        // that divert payment funds to external hooks before they reach the project's balance.
+        // Project owners MUST audit their data hooks with the same rigor as the terminal.
+
         // If the ruleset has a data hook enabled for payments, use it to derive a weight and memo.
         if (ruleset.useDataHookForPay() && ruleset.dataHook() != address(0)) {
             // Create the pay context that'll be sent to the data hook.

--- a/src/JBTerminalStore.sol
+++ b/src/JBTerminalStore.sol
@@ -527,6 +527,12 @@ contract JBTerminalStore is IJBTerminalStore {
         // Can't cash out more tokens than are in the supply.
         if (cashOutCount > totalSupply) revert JBTerminalStore_InsufficientTokens(cashOutCount, totalSupply);
 
+        // SECURITY NOTE: The data hook has absolute control over cash-out economics.
+        // It can set totalSupply, cashOutCount, and cashOutTaxRate to arbitrary values,
+        // completely overriding the terminal's bonding curve math. For example, setting
+        // totalSupply = surplus makes reclaimAmount = cashOutCount, bypassing the curve.
+        // Project owners MUST audit their data hooks with the same rigor as the terminal.
+
         // If the ruleset has a data hook which is enabled for cash outs, use it to derive a claim amount and memo.
         if (ruleset.useDataHookForCashOut() && ruleset.dataHook() != address(0)) {
             // Create the cash out context that'll be sent to the data hook.


### PR DESCRIPTION
Data hooks have absolute control over cash-out economics — they can return arbitrary totalSupply, cashOutCount, and cashOutTaxRate values. Discovered during defifa-v5 audit where the hook sets totalSupply = surplus to bypass the bonding curve entirely.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: