### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -38,7 +38,7 @@ contract Deploy is Script, Sphinx {
 
     /// @notice The nonce that gets used across all chains to sync deployment addresses and allow for new deployments of
     /// the same bytecode.
-    uint256 private CORE_DEPLOYMENT_NONCE = 1;
+    uint256 private CORE_DEPLOYMENT_NONCE = 6;
 
     function configureSphinx() public override {
         sphinxConfig.projectName = "nana-core-v5";

--- a/script/DeployPeriphery.s.sol
+++ b/script/DeployPeriphery.s.sol
@@ -38,12 +38,12 @@ contract DeployPeriphery is Script, Sphinx {
 
     address private TRUSTED_FORWARDER;
 
-    bytes32 private DEADLINES_SALT = keccak256("_JBDeadlines_");
-    bytes32 private USD_NATIVE_FEED_SALT = keccak256("USD_FEED");
+    bytes32 private DEADLINES_SALT = keccak256("_JBDeadlinesV6_");
+    bytes32 private USD_NATIVE_FEED_SALT = keccak256("USD_FEEDV6");
 
     /// @notice The nonce that gets used across all chains to sync deployment addresses and allow for new deployments of
     /// the same bytecode.
-    uint256 private CORE_DEPLOYMENT_NONCE = 1;
+    uint256 private CORE_DEPLOYMENT_NONCE = 6;
     address private OMNICHAIN_RULESET_OPERATOR = address(0x8f5DED85c40b50d223269C1F922A056E72101590);
 
     function configureSphinx() public override {


### PR DESCRIPTION
## Summary
- Changed `CORE_DEPLOYMENT_NONCE` from 1 to 6 in `Deploy.s.sol` and `DeployPeriphery.s.sol`
- Updated `DEADLINES_SALT` string from `_JBDeadlines_` to `_JBDeadlinesV6_`
- Updated `USD_NATIVE_FEED_SALT` string from `USD_FEED` to `USD_FEEDV6`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)