### PR TITLE
Fix NatSpec typos, bit ranges, and misleading comments

### DIFF
--- a/src/JBChainlinkV3SequencerPriceFeed.sol
+++ b/src/JBChainlinkV3SequencerPriceFeed.sol
@@ -14,7 +14,7 @@ contract JBChainlinkV3SequencerPriceFeed is JBChainlinkV3PriceFeed {
     //*********************************************************************//
 
     error JBChainlinkV3SequencerPriceFeed_SequencerDownOrRestarting(
-        uint256 timestamp, uint256 gradePeriodTime, uint256 startedAt
+        uint256 timestamp, uint256 gracePeriodTime, uint256 startedAt
     );
     error JBChainlinkV3SequencerPriceFeed_InvalidRound();
 
@@ -33,7 +33,7 @@ contract JBChainlinkV3SequencerPriceFeed is JBChainlinkV3PriceFeed {
     //*********************************************************************//
 
     /// @param feed The Chainlink feed to report prices from.
-    /// @param threshold How many blocks old a price update may be.
+    /// @param threshold How many seconds old a price update may be.
     /// @param sequencerFeed The Chainlink feed to report sequencer status.
     /// @param gracePeriod How long the sequencer should have been re-active before returning prices.
     constructor(

--- a/src/JBFeelessAddresses.sol
+++ b/src/JBFeelessAddresses.sol
@@ -15,7 +15,7 @@ contract JBFeelessAddresses is Ownable, IJBFeelessAddresses, IERC165 {
     /// @notice Check if the specified address is feeless.
     /// @dev Feeless addresses can receive payouts without incurring a fee.
     /// @dev Feeless addresses can use the surplus allowance without incurring a fee.
-    /// @dev Feeless addresses can be the beneficary of cash outs without incurring a fee.
+    /// @dev Feeless addresses can be the beneficiary of cash outs without incurring a fee.
     /// @custom:param addr The address to check.
     mapping(address addr => bool) public override isFeeless;
 

--- a/src/JBFundAccessLimits.sol
+++ b/src/JBFundAccessLimits.sol
@@ -101,7 +101,7 @@ contract JBFundAccessLimits is JBControlled, IJBFundAccessLimits {
     }
 
     /// @notice A project's payout limits for a given ruleset, terminal, and token.
-    /// @notice The total value of `token`s that a project can pay out from the terminal during the ruleset is dictated
+    /// @dev The total value of `token`s that a project can pay out from the terminal during the ruleset is dictated
     /// by a list of payout limits. Each payout limit is a fixed-point amount in terms of a currency.
     /// @dev The fixed point `amount`s returned will use the same number of decimals as the `terminal`.
     /// @param projectId The project's ID.
@@ -134,7 +134,7 @@ contract JBFundAccessLimits is JBControlled, IJBFundAccessLimits {
             // Set the data being iterated on.
             uint256 packedPayoutLimitData = packedPayoutLimitsData[i];
 
-            // The limit amount is in bits 0-231. The currency is in bits 224-255.
+            // The limit amount is in bits 0-223. The currency is in bits 224-255.
             payoutLimits[i] = JBCurrencyAmount({
                 currency: uint32(packedPayoutLimitData >> 224),
                 amount: uint224(packedPayoutLimitData)
@@ -183,7 +183,7 @@ contract JBFundAccessLimits is JBControlled, IJBFundAccessLimits {
     }
 
     /// @notice A project's surplus allowances for a given ruleset, terminal, and token.
-    /// @notice The total value of `token`s that a project can pay out from its surplus in a terminal during the ruleset
+    /// @dev The total value of `token`s that a project can pay out from its surplus in a terminal during the ruleset
     /// is dictated by a list of surplus allowances. Each surplus allowance is a fixed-point amount in terms of a
     /// currency.
     /// @dev The fixed point `amount`s returned will use the same number of decimals as the `terminal`.
@@ -281,7 +281,7 @@ contract JBFundAccessLimits is JBControlled, IJBFundAccessLimits {
 
             // Iterate through each surplus allowance to validate and store them.
             for (uint256 j; j < numberOfSurplusAllowances; j++) {
-                // Set the payout limit being iterated on.
+                // Set the surplus allowance being iterated on.
                 JBCurrencyAmount calldata surplusAllowance = fundAccessLimitGroup.surplusAllowances[j];
 
                 // Make sure the surplus allowances are passed in strictly increasing order (sorted by currency) to

--- a/src/libraries/JBFees.sol
+++ b/src/libraries/JBFees.sol
@@ -7,27 +7,22 @@ import {JBConstants} from "./../libraries/JBConstants.sol";
 
 /// @notice Fee calculations.
 library JBFees {
-    /// @notice Returns the amount of tokens to pay as a fee relative to the specified `amount`.
-    /// @param amountAfterFee The amount that the fee is based on, as a fixed point number.
+    /// @notice Returns the fee amount that, when added to `amountAfterFee`, produces the gross amount needed to yield
+    /// `amountAfterFee` after the fee is deducted.
+    /// @dev Use this to back-calculate the fee from a desired post-fee payout.
+    /// @param amountAfterFee The desired post-fee amount, as a fixed point number.
     /// @param feePercent The fee percent, out of `JBConstants.MAX_FEE`.
-    /// @return The amount of tokens to pay as a fee, as a fixed point number with the same number of decimals as the
-    /// provided `amount`.
+    /// @return The fee amount, as a fixed point number with the same number of decimals as the provided `amount`.
     function feeAmountResultingIn(uint256 amountAfterFee, uint256 feePercent) internal pure returns (uint256) {
-        // The amount of tokens from the `amount` to pay as a fee. If reverse, the fee taken from a payout of
-        // `amount`.
         return mulDiv(amountAfterFee, JBConstants.MAX_FEE, JBConstants.MAX_FEE - feePercent) - amountAfterFee;
     }
 
-    /// @notice Returns the fee that would have been paid based on an `amount` which has already had the fee subtracted
-    /// from it.
-    /// @param amountBeforeFee The amount that the fee is based on, as a fixed point number with the same amount of
-    /// decimals as
-    /// this terminal.
+    /// @notice Returns the fee that would be taken from `amountBeforeFee`.
+    /// @dev Use this to forward-calculate the fee from a known pre-fee amount.
+    /// @param amountBeforeFee The amount before the fee is applied, as a fixed point number.
     /// @param feePercent The fee percent, out of `JBConstants.MAX_FEE`.
-    /// @return The amount of the fee, as a fixed point number with the same amount of decimals as this terminal.
+    /// @return The fee amount, as a fixed point number with the same number of decimals as the provided `amount`.
     function feeAmountFrom(uint256 amountBeforeFee, uint256 feePercent) internal pure returns (uint256) {
-        // The amount of tokens from the `amount` to pay as a fee. If reverse, the fee taken from a payout of
-        // `amount`.
         return mulDiv(amountBeforeFee, feePercent, JBConstants.MAX_FEE);
     }
 }

--- a/src/libraries/JBSurplus.sol
+++ b/src/libraries/JBSurplus.sol
@@ -27,7 +27,7 @@ library JBSurplus {
         view
         returns (uint256 surplus)
     {
-        // Keep a reference to the number of termainls.
+        // Keep a reference to the number of terminals.
         uint256 numberOfTerminals = terminals.length;
 
         // Add the current surplus for each terminal.


### PR DESCRIPTION
## Summary

Fixes documentation issues across 5 files that are **not touched by any open PR**:

- **JBFeelessAddresses.sol**: Fix `beneficary` → `beneficiary` typo
- **JBFundAccessLimits.sol**: 
  - Fix `bits 0-231` → `bits 0-223` (uint224 is 224 bits, indices 0-223)
  - Fix copy-paste error: surplus allowance iterator comment said "payout limit"
  - Deduplicate `@notice` → `@dev` on `payoutLimitsOf()` and `surplusAllowancesOf()`
- **JBChainlinkV3SequencerPriceFeed.sol**: 
  - Fix `gradePeriodTime` → `gracePeriodTime` error param name
  - Fix `"How many blocks old"` → `"How many seconds old"` (threshold uses `block.timestamp`)
- **JBFees.sol**: Rewrite NatSpec for both functions — old descriptions were swapped/misleading (`feeAmountResultingIn` back-calculates from post-fee amount; `feeAmountFrom` forward-calculates from pre-fee amount)
- **JBSurplus.sol**: Fix `termainls` → `terminals` typo

## Test plan
- [x] `forge build` passes
- [ ] No logic changes — NatSpec and comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)