### PR TITLE
Enhance README with conceptual overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,47 @@
 
 The core protocol contracts for Juicebox V5 on EVM. A flexible toolkit for launching and managing a treasury-backed token on Ethereum and L2s.
 
+For full documentation, see [docs.juicebox.money](https://docs.juicebox.money/). If you have questions, reach out on [Discord](https://discord.com/invite/ErQYmth4dS).
+
+## Conceptual Overview
+
+Juicebox projects have two main entry points:
+
+- **Terminals** handle inflows and outflows of funds — payments, cash outs, payouts, and surplus allowance usage. Each project can use multiple terminals, and a single terminal can serve many projects. `JBMultiTerminal` is the standard implementation.
+- **Controllers** manage rulesets and tokens. `JBController` is the standard implementation that coordinates ruleset queuing, token minting/burning, splits, and fund access limits.
+
+`JBDirectory` maps each project to its controller and terminals.
+
+### Rulesets
+
+A project's behavior is governed by a queue of **rulesets**. Each ruleset defines the rules that apply for a specific duration: payment weight (tokens minted per unit paid), cash out rate, reserved rate, payout limits, approval hooks, and more. When a ruleset ends, the next one in the queue takes effect. If the queue is empty, the current ruleset keeps cycling with weight decay applied each cycle. Rulesets give project creators the ability to evolve their project's rules while offering supporters contractual guarantees about the future.
+
+### Fund Distribution
+
+Funds can be accessed through **payouts** (distributed to splits within payout limits, resetting each ruleset) or **surplus allowance** (discretionary withdrawal of surplus funds, does not reset). Funds beyond payout limits are surplus — available for cash outs if the project's cash out rate allows it.
+
+### Payments, Tokens, and Cash Outs
+
+Payments mint credits (or ERC-20 tokens if deployed) for the payer. Credits and tokens can be **cashed out** to reclaim surplus funds along a bonding curve determined by the cash out rate. A 100% rate gives 1:1 redemption; lower rates incentivize holding by giving later redeemers a better rate.
+
+### Permissions
+
+`JBPermissions` lets addresses delegate specific capabilities to operators, scoped by project ID. Each permission ID grants access to specific functions (see [`JBPermissionIds`](https://github.com/Bananapus/nana-permission-ids-v5/blob/main/src/JBPermissionIds.sol) for the full list of 30 permission IDs used across the protocol).
+
+### Hooks
+
+Hooks are customizable contracts that plug into protocol flows:
+
+- **Approval hooks** — Gate whether the next queued ruleset can take effect (e.g., `JBDeadline` enforces a minimum queue time).
+- **Data hooks** — Override payment/cash-out weight or memo, and specify pay/cash-out hooks to call.
+- **Pay hooks** — Custom logic triggered after a payment is recorded (e.g., `JB721TiersHook` mints NFTs).
+- **Cash out hooks** — Custom logic triggered after a cash out is recorded.
+- **Split hooks** — Custom logic triggered when a payout is routed to a split.
+
+### Fees
+
+`JBMultiTerminal` charges a 2.5% fee on payouts to addresses (not to other projects), surplus allowance usage, and cash outs when the cash out rate is below 100%.
+
 ## Architecture
 
 Juicebox V5 separates concerns across specialized contracts that coordinate through a central directory. Projects are represented as ERC-721 NFTs. Each project configures rulesets that dictate how payments, payouts, cash outs, and token minting behave over time.


### PR DESCRIPTION
## Summary
- Adds condensed conceptual overview covering rulesets, fund distribution, payments/tokens/cash outs, permissions, hooks, and fees
- Adds links to full docs (docs.juicebox.money), Discord, and permission IDs reference
- Keeps the structured architecture tables, contract descriptions, and accurate install/develop instructions from the new format

Same enhancements as the `readme-and-skills` branch PR, targeting `version/6`.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)